### PR TITLE
📝 Remove deprecated live demo link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > _테이블 형태로 맥주 정보를 제공하는 미니 어플리케이션입니다._
 
-- **Live Demo** : [https://beer-table.vercel.app](https://beer-table.vercel.app/)
+- ~~**Live Demo** : [https://beer-table.vercel.app](https://beer-table.vercel.app/)~~
 - 작업기간 6일
 
 ## 사용 스택 / 라이브러리


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Mark live demo link as deprecated using strikethrough formatting

- Indicates the demo URL is no longer actively maintained


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md"] -- "strikethrough deprecated link" --> B["Live Demo marked as inactive"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Strikethrough deprecated live demo link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Applied strikethrough formatting to the Live Demo link line<br> <li> Indicates the Vercel deployment is no longer active<br> <li> Preserves the link reference while marking it as deprecated</ul>


</details>


  </td>
  <td><a href="https://github.com/romantech/beer-table/pull/36/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

